### PR TITLE
Fix relative target of manpage links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ install: mocassin mocassinWarm mocassinOutput mocassinPlot
 	cp -R examples $(DESTDIR)$(PREFIX)/share/mocassin
 	install -m 644 man/mocassin.1 $(MANDIR)
 	gzip -f $(MANDIR)/mocassin.1
-	ln -s -f $(MANDIR)/mocassin.1.gz $(MANDIR)/mocassinWarm.1.gz
-	ln -s -f $(MANDIR)/mocassin.1.gz $(MANDIR)/mocassinOutput.1.gz
-	ln -s -f $(MANDIR)/mocassin.1.gz $(MANDIR)/mocassinPlot.1.gz
+	ln -s -f mocassin.1.gz $(MANDIR)/mocassinWarm.1.gz
+	ln -s -f mocassin.1.gz $(MANDIR)/mocassinOutput.1.gz
+	ln -s -f mocassin.1.gz $(MANDIR)/mocassinPlot.1.gz
 	install mocassin $(DESTDIR)$(PREFIX)/bin
 	install mocassinWarm $(DESTDIR)$(PREFIX)/bin
 	install mocassinPlot $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that mocassin could not be built reproducibly.

This led me to discover that the `mocassinOutput(1)`, `mocassinPlot(1)` and `mocassinWarm(1)` manpages were linking to the absolute location for the `mocassin(1)` manpage, so they would not work when distributed:

For example `mocassinOutput.1.gz` linked to, on my machine:

```
/home/lamby/temp/cdt.20210215121553.ZpEolGOptg.repro.mocassin/build-a/mocassin-2.02.73.1/debian/tmp/usr/share/man/man1/mocassin.1.gz
```

Patch attached that uses relative URLs instead. This change would also make the build reproducible. I originally filed this in Debian as [#982851](https://bugs.debian.org/982851).